### PR TITLE
Update navigation.yaml to link to the new portfolio tracker

### DIFF
--- a/_data/navigation.yaml
+++ b/_data/navigation.yaml
@@ -39,5 +39,5 @@ secondary_navigation:
     - name: Rubric
       url: /rubric/
     - name: Tracker
-      url: "https://airtable.com/shrsMy2dpZDPbWTXW"
+      url: "https://share.cms.gov/center/CMCS/DSG/DSS/Lists/MESStatePortfolios/AllItems.aspx"
       external: true


### PR DESCRIPTION
This PR changes the tracker link in the header from airtable to our new sharepoint portfolio tracker page. Woot Woot!